### PR TITLE
Fix tab separated parsing

### DIFF
--- a/index/baseline.py
+++ b/index/baseline.py
@@ -48,7 +48,7 @@ def baseline_index(input_file):
                 line = fp.readline()
                 continue
 
-            line = line.replace("<", "").replace(">", "").replace("\n", "")
+            line = line.replace("<", "").replace(">", "").replace("\n", "").replace("\t"," ")
             contents = line.split(" ", 2)
 
             if len(contents) < 3:

--- a/index/extended.py
+++ b/index/extended.py
@@ -65,7 +65,7 @@ def extended_index(input_file):
                 line = fp.readline()
                 continue
 
-            line = line.replace("<", "").replace(">", "").replace("\n", "")
+            line = line.replace("<", "").replace(">", "").replace("\n", "").replace("\t"," ")
             contents = line.split(" ", 2)
 
             if len(contents) < 3:


### PR DESCRIPTION
some triples separated with tabs after the replace function were in a form like: "subject\tpredicate\tobject". As a result, the "contents" variable length was smaller than 3 and the triple was skipped.